### PR TITLE
update the empty jar logo

### DIFF
--- a/src/validators/mainnet.json
+++ b/src/validators/mainnet.json
@@ -347,7 +347,7 @@
     },
     {
       "id": "0xb77084d2b92baa3e01ec5ce57fbd529d3c8e60941c637bdc7c85d9ca2cc56545c3cbea86879dcbe9402f8a55d0284e7b",
-      "logoURI": "https://cdn.discordapp.com/attachments/1330919758706638848/1342692350991925381/IMG_2537.png?ex=67ba8f32&is=67b93db2&hm=e1095260a666d13a366e9f149d29792bd9ae168049af3dbb9c6d471382c40971&",
+      "logoURI": "https://res.cloudinary.com/duv0g402y/image/upload/c_thumb,w_200,g_face/v1740538962/src/validators/mainnet/ollxsvawywocamy0p8lu.png",
       "name": "The Empty Jar",
       "description": "The Empty Jar is used for THJ internal and experimental projects. Do not expect this validator to offer competitive incentives.",
       "website": "https://www.0xhoneyjar.xyz/",


### PR DESCRIPTION
with camem help we propose update the logo of the empty jar from discord cdn to cloudinary.