### PR TITLE
Updated BERA to wBERA so as to correctly reference the token in use.

### DIFF
--- a/src/vaults/mainnet.json
+++ b/src/vaults/mainnet.json
@@ -442,11 +442,11 @@
     {
       "stakingTokenAddress": "0xc227C8639A41db8393DD1B4EAc41464a62D64Fb4",
       "vaultAddress": "0xde9d49a63fbb7c7d211b26a7d0dabdf8e0d4b4fe",
-      "name": "Olympus - OHM | BERA",
+      "name": "Olympus - OHM | wBERA",
       "protocol": "Kodiak",
       "logoURI": "https://res.cloudinary.com/duv0g402y/image/upload/c_thumb,w_200,g_face/v1742844655/reward-vaults/icons/fzhm2cubp35ezzfa1uhq.png",
       "url": "https://app.kodiak.finance/#/liquidity/pools/0xc227c8639a41db8393dd1b4eac41464a62d64fb4?farm=0x3c8e4d4324f7ab2e3238c23a2838a762ecb7051d&chain=berachain_mainnet",
-      "description": "Acquired by depositing liquidity into the Olympus - OHM | BERA Pool on Kodiak",
+      "description": "Acquired by depositing liquidity into the Olympus - OHM | wBERA Pool on Kodiak",
       "owner": "Olympus"
     }
   ]


### PR DESCRIPTION
At Teddy's request, we are submitting a PR to change BERA to wBERA as that is the actual token used in the LP and Reward Vault.  We will coordinate with Kodiak to change the name on their side as well.