### PR TITLE
fix: update error message for missing headers

### DIFF
--- a/scripts/validateImages.ts
+++ b/scripts/validateImages.ts
@@ -106,9 +106,13 @@ const validateAssetsImages = () => {
             }
           }
 
+          if (dimensions === null) {
+            errors.push(
+              `${relativePath}: Unsupported file format. Unable to determine image dimensions.`,
+            );
+          }
           // Validate dimensions
-          if (
-            !dimensions ||
+          else if (
             dimensions.width < 1024 ||
             dimensions.height < 1024 ||
             dimensions?.width !== dimensions?.height


### PR DESCRIPTION
# Summary

Displayed `undefinedxundefined` when an image is missing the required headers.

https://github.com/berachain/metadata/actions/runs/14520907923/job/40855922584?pr=156