### PR TITLE
Removed usda

### DIFF
--- a/src/tokens/mainnet.json
+++ b/src/tokens/mainnet.json
@@ -557,18 +557,6 @@
     },
     {
       "chainId": 80094,
-      "address": "0xff12470a969Dd362EB6595FFB44C82c959Fe9ACc",
-      "name": "USDa",
-      "symbol": "USDa",
-      "decimals": 18,
-      "logoURI": "https://imagedelivery.net/qNj7Q3MCke89zoKzav7eDQ/tokens/0xff12470a969dd362eb6595ffb44c82c959fe9acc.png/public",
-      "extensions": {
-        "coingeckoId": "usda-2",
-        "pythPriceId": "0x3a1050a3c03354c94ed44acf808327f05b7f9d610f38644684f5ce4796cce27b"
-      }
-    },
-    {
-      "chainId": 80094,
       "address": "0x2840F9d9f96321435Ab0f977E7FDBf32EA8b304f",
       "name": "USDa saving token",
       "symbol": "sUSDa",


### PR DESCRIPTION
Yes, it was a deliberate deactivation, and today is exactly the day it happened.
Pyth USDa/USD Feed Deactivation — April 15, 2026
TL;DR: Pyth formally deactivated Crypto.USDA/USD (your feed ID 0x3a1050...) today at 4:11 PM as part of a batch of 7 feeds. It was announced 2+ weeks ago on their developer forum.
Root Cause: Angle Protocol Shutdown
[Angle Protocol](https://www.angle.money/) — the issuer of USDa — is winding down operations. Their site now reads:
"Angle is entering its final chapter. Every USDA and EURA is redeemable 1:1. Redeem before March 1, 2027."
Pyth's policy is to sunset feeds when the underlying asset is deprecated by its issuer.
Official Announcement
Pyth posted [Price Feeds Upcoming Deactivations – April 15th, 2026](https://dev-forum.pyth.network/t/price-feeds-upcoming-deactivations-april-15th-2026/702) on March 30, 2026, listing 7 feeds for removal including:
Crypto.USDA/USD ← your feed
Crypto.stUSD/USDA.RR ← companion Angle Protocol feed
[Crypto.OM/USD](http://crypto.om/USD)
Crypto.MAG7-SSI/USD
Crypto.SXP/USD
Crypto.WOJAK/USD
[Equity.US](http://equity.us/).SPLG/USD
The pyth.network/price-feeds/crypto-usda-usd page now permanently redirects to insights.pyth.network/legacy-price-feeds/crypto-usda-usd.
What You Should Do
If your system depends on this feed, you have a few options:
Remove the feed dependency — USDa is being sunset, so the price is no longer meaningful
Use a different stablecoin oracle if you need a USD-pegged reference
Handle the "feed not found" case gracefully in your code so it doesn't break anything