### PR TITLE
ci: auto-upload contributor images to Cloudflare

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -132,8 +132,87 @@ jobs:
         BERACHAIN_HUB_API_BASE_URL: ${{ secrets.BERACHAIN_HUB_API_BASE_URL }}
       run: pnpm validate:data head
 
+  detect-changes:
+    runs-on: ubuntu-latest
+    outputs:
+      assets-changed: ${{ steps.filter.outputs.assets }}
+    steps:
+    - uses: actions/checkout@v4
+    - id: filter
+      uses: dorny/paths-filter@v3
+      with:
+        base: ${{ github.event.pull_request.base.sha }}
+        ref: ${{ github.event.pull_request.head.sha }}
+        filters: |
+          assets:
+            - 'src/assets/**'
+
+  upload-assets:
+    needs: [schema, detect-changes]
+    if: needs.detect-changes.outputs.assets-changed == 'true'
+    runs-on: ubuntu-latest
+    environment: cloudflare-uploads
+    permissions:
+      contents: read
+      pull-requests: write
+
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/checkout@v4
+      with:
+        repository: ${{ github.event.pull_request.head.repo.full_name }}
+        ref: ${{ github.event.pull_request.head.sha }}
+        path: ./head
+        persist-credentials: false
+
+    - name: Setup Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version-file: '.nvmrc'
+
+    - name: Setup pnpm
+      uses: pnpm/action-setup@v2
+      with:
+        version: 9.15.9
+
+    - name: Get pnpm store directory
+      shell: bash
+      run: |
+        echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
+
+    - name: Setup pnpm cache
+      uses: actions/cache@v4
+      with:
+        path: ${{ env.STORE_PATH }}
+        key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+        restore-keys: |
+          ${{ runner.os }}-pnpm-store-
+
+    - name: Install dependencies
+      run: pnpm install
+
+    - name: Upload changed images to Cloudflare Images
+      env:
+        CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        CLOUDFLARE_IMAGES_API_TOKEN: ${{ secrets.CLOUDFLARE_IMAGES_API_TOKEN }}
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GITHUB_REPOSITORY: ${{ github.repository }}
+        PR_NUMBER: ${{ github.event.pull_request.number }}
+      run: pnpm upload:assets ./head
+
+    - name: Post summary comment
+      if: always()
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        PR: ${{ github.event.pull_request.number }}
+      run: |
+        if [ -s "$GITHUB_STEP_SUMMARY" ]; then
+          gh pr comment "$PR" --body-file "$GITHUB_STEP_SUMMARY"
+        fi
+
   images:
-    needs: schema
+    needs: [schema, upload-assets]
+    if: always() && needs.schema.result == 'success' && (needs.upload-assets.result == 'success' || needs.upload-assets.result == 'skipped')
     runs-on: ubuntu-latest
 
     steps:
@@ -169,7 +248,7 @@ jobs:
 
     - name: Install dependencies
       run: pnpm install
-      
+
     - name: Validate images
       run: |
         pnpm validate:images head

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,6 +12,12 @@ PLEASE NOTE:
 - Submitting a PR _DOES NOT_ guarantee addition to the lists
 - All PRs should include relevant assets in the `assets/` directory
 
+### What happens after you open the PR
+
+If your PR adds or modifies files under `src/assets/`, a maintainer must approve the `cloudflare-uploads` deployment before the `images` check can run. You don't need to do anything — expect the `images` check to sit in "waiting for review" until a maintainer approves the upload. Once approved, the workflow uploads your image to Cloudflare Images and re-runs validation; the check then turns green.
+
+If your PR only edits JSON files (no new images), the `upload-assets` job is skipped and validation runs normally — no approval needed.
+
 ### Adding a Token
 
 ```json

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "preinstall": "npx only-allow pnpm",
     "format": "biome format --write",
     "validate:images": "tsx scripts/validateImages.ts",
+    "upload:assets": "tsx scripts/uploadAssets.ts",
     "validate:json": "tsx scripts/validateJSON.ts",
     "validate:data": "tsx scripts/validateOnChainData/main.ts",
     "validate:pyth": "tsx scripts/validatePythPriceIds.ts",

--- a/scripts/uploadAssets.ts
+++ b/scripts/uploadAssets.ts
@@ -1,0 +1,440 @@
+/**
+ * Uploads contributor-added images under src/assets/{tokens,vaults,validators}
+ * to Cloudflare Images. Intended to run inside the `upload-assets` CI job after
+ * a maintainer has approved the `cloudflare-uploads` environment deployment.
+ *
+ * Usage: tsx scripts/uploadAssets.ts <pr-head-dir>
+ *
+ * Required env:
+ *   CLOUDFLARE_ACCOUNT_ID, CLOUDFLARE_IMAGES_API_TOKEN
+ *   GITHUB_REPOSITORY, PR_NUMBER, GH_TOKEN (for resolving changed files via gh)
+ *
+ * The script:
+ *   1. Resolves the list of added/modified files under src/assets/** on the PR
+ *      via `gh api /repos/{repo}/pulls/{pr}/files --paginate`.
+ *   2. Per-file validates path, filename, extension, EIP-55 checksum (where
+ *      applicable), 1024x1024 dimensions, PNG non-transparency, and 5 MB cap.
+ *   3. Uploads to Cloudflare Images with id = "{type}/{filename}". On a 5409
+ *      ALREADY_EXISTS error, DELETEs the existing image and retries once.
+ *   4. Writes a summary to $GITHUB_STEP_SUMMARY and stdout, then exits non-zero
+ *      if any file failed.
+ */
+
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import chalk from "chalk";
+import {
+  getImageDimensions,
+  hasTransparency,
+  isValidChecksumAddress,
+} from "./utils/_imageChecks";
+
+const HEAD_DIR = process.argv[2];
+
+if (!HEAD_DIR) {
+  console.error("Usage: tsx scripts/uploadAssets.ts <pr-head-dir>");
+  process.exit(1);
+}
+
+const CLOUDFLARE_ACCOUNT_ID = process.env.CLOUDFLARE_ACCOUNT_ID;
+const CLOUDFLARE_IMAGES_API_TOKEN = process.env.CLOUDFLARE_IMAGES_API_TOKEN;
+const GITHUB_REPOSITORY = process.env.GITHUB_REPOSITORY;
+const PR_NUMBER = process.env.PR_NUMBER;
+
+if (
+  !CLOUDFLARE_ACCOUNT_ID ||
+  !CLOUDFLARE_IMAGES_API_TOKEN ||
+  !GITHUB_REPOSITORY ||
+  !PR_NUMBER
+) {
+  console.error(
+    "Missing required env vars. Need: CLOUDFLARE_ACCOUNT_ID, CLOUDFLARE_IMAGES_API_TOKEN, GITHUB_REPOSITORY, PR_NUMBER",
+  );
+  process.exit(1);
+}
+
+const ALLOWED_TYPES = ["tokens", "vaults", "validators"] as const;
+type AssetType = (typeof ALLOWED_TYPES)[number];
+
+const ALLOWED_EXTENSIONS = [".png", ".jpg", ".jpeg"] as const;
+const REQUIRED_DIMENSION = 1024;
+const MAX_FILE_SIZE = 5 * 1024 * 1024;
+const CF_API_BASE = `https://api.cloudflare.com/client/v4/accounts/${CLOUDFLARE_ACCOUNT_ID}/images/v1`;
+
+type Status = "uploaded" | "overwritten" | "skipped" | "failed";
+
+interface Result {
+  file: string;
+  status: Status;
+  message: string;
+}
+
+interface FileCheckOk {
+  ok: true;
+  type: AssetType;
+  id: string;
+  basename: string;
+  ext: string;
+}
+
+interface FileCheckErr {
+  ok: false;
+  reason: string;
+}
+
+interface CloudflareResponse {
+  success?: boolean;
+  errors?: { code?: number; message?: string }[];
+  result?: { id?: string; filename?: string; variants?: string[] };
+}
+
+// File list resolution
+// ================================================================
+const fetchChangedAssetFiles = (): string[] => {
+  // `gh api --paginate --jq` emits JSONL (one object per line) when jq
+  // produces per-element output. Parse that into a typed list.
+  const raw = execFileSync(
+    "gh",
+    [
+      "api",
+      `repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/files`,
+      "--paginate",
+      "--jq",
+      ".[] | {filename, status}",
+    ],
+    { encoding: "utf-8" },
+  );
+
+  const entries = raw
+    .split("\n")
+    .map((l) => l.trim())
+    .filter(Boolean)
+    .map((l) => JSON.parse(l) as { filename: string; status: string });
+
+  return entries
+    .filter(
+      (e) =>
+        e.status === "added" ||
+        e.status === "modified" ||
+        e.status === "changed" ||
+        e.status === "renamed",
+    )
+    .filter((e) => e.filename.startsWith("src/assets/"))
+    .map((e) => e.filename);
+};
+
+// Per-file static validation
+// ================================================================
+const validatePath = (relPath: string): FileCheckOk | FileCheckErr => {
+  // Must be exactly src/assets/<type>/<filename> — no deeper nesting, no "..".
+  const normalized = path.posix.normalize(relPath);
+  if (normalized !== relPath || normalized.includes("..")) {
+    return { ok: false, reason: "path normalization mismatch or contains .." };
+  }
+
+  const parts = normalized.split("/");
+  if (parts.length !== 4 || parts[0] !== "src" || parts[1] !== "assets") {
+    return {
+      ok: false,
+      reason: `path must be src/assets/<type>/<filename>, got depth ${parts.length}`,
+    };
+  }
+
+  const type = parts[2];
+  const filename = parts[3];
+  if (!ALLOWED_TYPES.includes(type as AssetType)) {
+    return {
+      ok: false,
+      reason: `type must be one of ${ALLOWED_TYPES.join("/")}, got "${type}"`,
+    };
+  }
+
+  const ext = path.extname(filename).toLowerCase();
+  if (
+    !ALLOWED_EXTENSIONS.includes(ext as (typeof ALLOWED_EXTENSIONS)[number])
+  ) {
+    return {
+      ok: false,
+      reason: `extension must be png/jpg/jpeg, got "${ext}"`,
+    };
+  }
+
+  const basename = filename.slice(0, filename.length - ext.length);
+
+  if (type === "validators") {
+    if (!/^0x[0-9a-f]{96}$/i.test(basename)) {
+      return {
+        ok: false,
+        reason: "filename must be 0x + 96 hex chars (validator pubkey)",
+      };
+    }
+  } else {
+    // tokens or vaults
+    if (!/^0x[0-9a-f]{40}$/i.test(basename)) {
+      return {
+        ok: false,
+        reason: "filename must be 0x + 40 hex chars (address)",
+      };
+    }
+    if (!isValidChecksumAddress(basename)) {
+      return {
+        ok: false,
+        reason: "address is not in EIP-55 checksum format",
+      };
+    }
+  }
+
+  return {
+    ok: true,
+    type: type as AssetType,
+    id: `${type}/${filename}`,
+    basename,
+    ext,
+  };
+};
+
+const validateImageContent = async (
+  absPath: string,
+  ext: string,
+): Promise<{ ok: true } | { ok: false; reason: string }> => {
+  const stat = fs.statSync(absPath);
+  if (stat.size > MAX_FILE_SIZE) {
+    return {
+      ok: false,
+      reason: `file size ${stat.size}B exceeds ${MAX_FILE_SIZE}B cap`,
+    };
+  }
+
+  const dimensions = getImageDimensions(absPath);
+  if (!dimensions) {
+    return {
+      ok: false,
+      reason: "could not parse image header (unsupported format)",
+    };
+  }
+  if (
+    dimensions.width !== REQUIRED_DIMENSION ||
+    dimensions.height !== REQUIRED_DIMENSION
+  ) {
+    return {
+      ok: false,
+      reason: `dimensions ${dimensions.width}x${dimensions.height} must be ${REQUIRED_DIMENSION}x${REQUIRED_DIMENSION}`,
+    };
+  }
+
+  if (ext === ".png") {
+    const transparent = await hasTransparency(absPath);
+    if (transparent) {
+      return { ok: false, reason: "PNG has transparent pixels" };
+    }
+  }
+
+  return { ok: true };
+};
+
+// Cloudflare upload
+// ================================================================
+const deleteImage = async (id: string): Promise<boolean> => {
+  const response = await fetch(`${CF_API_BASE}/${id}`, {
+    method: "DELETE",
+    headers: { Authorization: `Bearer ${CLOUDFLARE_IMAGES_API_TOKEN}` },
+  });
+  const body = (await response.json()) as CloudflareResponse;
+  return response.ok && body.success === true;
+};
+
+const uploadImage = async (
+  absPath: string,
+  id: string,
+  basename: string,
+): Promise<CloudflareResponse & { httpStatus: number }> => {
+  const buf = fs.readFileSync(absPath);
+  const ab = new ArrayBuffer(buf.byteLength);
+  new Uint8Array(ab).set(buf);
+  const formData = new FormData();
+  formData.append("file", new Blob([ab]), basename);
+  formData.append("id", id);
+
+  const response = await fetch(CF_API_BASE, {
+    method: "POST",
+    headers: { Authorization: `Bearer ${CLOUDFLARE_IMAGES_API_TOKEN}` },
+    body: formData,
+  });
+  const body = (await response.json()) as CloudflareResponse;
+  return { ...body, httpStatus: response.status };
+};
+
+const uploadWithOverwrite = async (
+  absPath: string,
+  id: string,
+  basename: string,
+): Promise<{ status: Exclude<Status, "skipped">; message: string }> => {
+  const first = await uploadImage(absPath, id, basename);
+  if (first.success) {
+    return { status: "uploaded", message: "ok" };
+  }
+
+  const alreadyExists = first.errors?.some((e) => e.code === 5409);
+  if (!alreadyExists) {
+    return {
+      status: "failed",
+      message: `cloudflare upload failed (HTTP ${first.httpStatus}): ${JSON.stringify(first.errors ?? first)}`,
+    };
+  }
+
+  // DELETE then retry once — "overwrite" mode per approved plan.
+  const deleted = await deleteImage(id);
+  if (!deleted) {
+    return {
+      status: "failed",
+      message: `image already exists and DELETE to overwrite failed for id=${id}`,
+    };
+  }
+
+  const second = await uploadImage(absPath, id, basename);
+  if (second.success) {
+    return { status: "overwritten", message: "deleted + re-uploaded" };
+  }
+
+  return {
+    status: "failed",
+    message: `overwrite re-upload failed (HTTP ${second.httpStatus}): ${JSON.stringify(second.errors ?? second)}`,
+  };
+};
+
+// Summary
+// ================================================================
+const renderSummary = (results: Result[]): string => {
+  const uploaded = results.filter((r) => r.status === "uploaded");
+  const overwritten = results.filter((r) => r.status === "overwritten");
+  const skipped = results.filter((r) => r.status === "skipped");
+  const failed = results.filter((r) => r.status === "failed");
+
+  const lines: string[] = [];
+  lines.push("## Cloudflare asset upload summary");
+  lines.push("");
+  lines.push(`- Uploaded: **${uploaded.length}**`);
+  lines.push(`- Overwritten: **${overwritten.length}**`);
+  lines.push(`- Skipped: **${skipped.length}**`);
+  lines.push(`- Failed: **${failed.length}**`);
+  lines.push("");
+
+  if (results.length > 0) {
+    lines.push("| Status | File | Detail |");
+    lines.push("| --- | --- | --- |");
+    for (const r of results) {
+      lines.push(
+        `| ${r.status} | \`${r.file}\` | ${r.message.replace(/\|/g, "\\|")} |`,
+      );
+    }
+  } else {
+    lines.push("_No asset files changed in this PR._");
+  }
+
+  return lines.join("\n");
+};
+
+const writeSummary = (body: string) => {
+  const summaryPath = process.env.GITHUB_STEP_SUMMARY;
+  if (summaryPath) {
+    fs.appendFileSync(summaryPath, `${body}\n`);
+  }
+};
+
+// Main
+// ================================================================
+const main = async () => {
+  const changed = fetchChangedAssetFiles();
+  console.log(
+    chalk.cyan(
+      `Found ${changed.length} changed/added file(s) under src/assets/`,
+    ),
+  );
+
+  const results: Result[] = [];
+
+  for (const relPath of changed) {
+    const absPath = path.join(HEAD_DIR, relPath);
+
+    if (!fs.existsSync(absPath)) {
+      results.push({
+        file: relPath,
+        status: "skipped",
+        message: "file not present in PR head (possibly deleted after rename)",
+      });
+      continue;
+    }
+
+    const fileCheck = validatePath(relPath);
+    if (!fileCheck.ok) {
+      results.push({
+        file: relPath,
+        status: "failed",
+        message: fileCheck.reason,
+      });
+      continue;
+    }
+
+    const contentCheck = await validateImageContent(absPath, fileCheck.ext);
+    if (!contentCheck.ok) {
+      results.push({
+        file: relPath,
+        status: "failed",
+        message: contentCheck.reason,
+      });
+      continue;
+    }
+
+    console.log(chalk.blue(`Uploading ${relPath} → id=${fileCheck.id}`));
+    const upload = await uploadWithOverwrite(
+      absPath,
+      fileCheck.id,
+      `${fileCheck.basename}${fileCheck.ext}`,
+    );
+    results.push({
+      file: relPath,
+      status: upload.status,
+      message: upload.message,
+    });
+  }
+
+  const summary = renderSummary(results);
+  console.log();
+  console.log(summary);
+  writeSummary(summary);
+
+  // Machine-readable output for anyone parsing stdout.
+  console.log();
+  console.log(
+    JSON.stringify(
+      {
+        uploaded: results
+          .filter((r) => r.status === "uploaded")
+          .map((r) => r.file),
+        overwritten: results
+          .filter((r) => r.status === "overwritten")
+          .map((r) => r.file),
+        skipped: results
+          .filter((r) => r.status === "skipped")
+          .map((r) => r.file),
+        failed: results
+          .filter((r) => r.status === "failed")
+          .map((r) => ({ file: r.file, error: r.message })),
+      },
+      null,
+      2,
+    ),
+  );
+
+  const failedCount = results.filter((r) => r.status === "failed").length;
+  if (failedCount > 0) {
+    console.error(chalk.red.bold(`\n${failedCount} file(s) failed`));
+    process.exit(1);
+  }
+};
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/uploadAssets.ts
+++ b/scripts/uploadAssets.ts
@@ -162,26 +162,35 @@ const validatePath = (relPath: string): FileCheckOk | FileCheckErr => {
 
   const basename = filename.slice(0, filename.length - ext.length);
 
-  if (type === "validators") {
-    if (!/^0x[0-9a-f]{96}$/i.test(basename)) {
-      return {
-        ok: false,
-        reason: "filename must be 0x + 96 hex chars (validator pubkey)",
-      };
-    }
-  } else {
-    // tokens or vaults
-    if (!/^0x[0-9a-f]{40}$/i.test(basename)) {
-      return {
-        ok: false,
-        reason: "filename must be 0x + 40 hex chars (address)",
-      };
-    }
-    if (!isValidChecksumAddress(basename)) {
-      return {
-        ok: false,
-        reason: "address is not in EIP-55 checksum format",
-      };
+  // Default fallback images (e.g. default.png, validator-default.png) are
+  // repo-wide placeholders, not tied to a specific address/pubkey. Mirror
+  // the exemption in validateImages.ts so legitimate default-logo refreshes
+  // aren't blocked by the address/checksum checks. They still go through
+  // the dimension + transparency gates downstream.
+  const isDefault = basename.toLowerCase().includes("default");
+
+  if (!isDefault) {
+    if (type === "validators") {
+      if (!/^0x[0-9a-f]{96}$/i.test(basename)) {
+        return {
+          ok: false,
+          reason: "filename must be 0x + 96 hex chars (validator pubkey)",
+        };
+      }
+    } else {
+      // tokens or vaults
+      if (!/^0x[0-9a-f]{40}$/i.test(basename)) {
+        return {
+          ok: false,
+          reason: "filename must be 0x + 40 hex chars (address)",
+        };
+      }
+      if (!isValidChecksumAddress(basename)) {
+        return {
+          ok: false,
+          reason: "address is not in EIP-55 checksum format",
+        };
+      }
     }
   }
 

--- a/scripts/utils/_imageChecks.ts
+++ b/scripts/utils/_imageChecks.ts
@@ -1,0 +1,80 @@
+import fs from "node:fs";
+import sharp from "sharp";
+import { isAddress } from "viem";
+
+/**
+ * Validates if an Ethereum address is in proper EIP-55 checksum format.
+ */
+export const isValidChecksumAddress = (address: string): boolean => {
+  return isAddress(address);
+};
+
+/**
+ * Reads the dimensions of a PNG or JPG file from its header bytes.
+ * Returns null for unsupported formats.
+ */
+export const getImageDimensions = (
+  imagePath: string,
+): { width: number; height: number } | null => {
+  const buffer = fs.readFileSync(imagePath);
+
+  // PNG: 89 50 4e 47 0d 0a 1a 0a, width/height at bytes 16-19 / 20-23
+  if (buffer.slice(0, 8).toString("hex") === "89504e470d0a1a0a") {
+    const width = buffer.readUInt32BE(16);
+    const height = buffer.readUInt32BE(20);
+    return { width, height };
+  }
+
+  // JPG: ff d8, scan for SOF marker (0xC0-0xC3) to extract dimensions
+  if (buffer.slice(0, 2).toString("hex") === "ffd8") {
+    let i = 2;
+    while (i < buffer.length) {
+      const segmentLength = buffer.readUInt16BE(i + 2);
+      if (
+        buffer[i] === 0xff &&
+        buffer[i + 1] >= 0xc0 &&
+        buffer[i + 1] <= 0xc3
+      ) {
+        const height = buffer.readUInt16BE(i + 5);
+        const width = buffer.readUInt16BE(i + 7);
+        return { width, height };
+      }
+      i += segmentLength + 2;
+    }
+  }
+
+  return null;
+};
+
+/**
+ * Checks if a PNG image has any transparent pixels. Returns false for non-PNG.
+ */
+export const hasTransparency = async (imagePath: string): Promise<boolean> => {
+  try {
+    const image = sharp(imagePath);
+    const metadata = await image.metadata();
+
+    if (metadata.format !== "png") {
+      return false;
+    }
+
+    const { data } = await image
+      .raw()
+      .ensureAlpha()
+      .toBuffer({ resolveWithObject: true });
+
+    for (let i = 3; i < data.length; i += 4) {
+      if (data[i] < 255) {
+        return true;
+      }
+    }
+
+    return false;
+  } catch (error) {
+    console.warn(
+      `Warning: Could not check transparency for ${imagePath}:`,
+      error,
+    );
+    return false;
+  }
+};

--- a/scripts/utils/_imageChecks.ts
+++ b/scripts/utils/_imageChecks.ts
@@ -10,22 +10,45 @@ export const isValidChecksumAddress = (address: string): boolean => {
 };
 
 /**
- * Reads the dimensions of a PNG or JPG file from its header bytes.
- * Returns null for unsupported formats.
+ * Reads image dimensions straight out of the file header — no decode, no
+ * third-party dep. PNG has a fixed layout so it's a direct offset read; JPG
+ * stores dimensions inside a variable-length chain of markers so we walk the
+ * segments until we find a Start-Of-Frame. Returns null for anything else
+ * (webp/gif/bmp/tiff are rejected upstream).
  */
 export const getImageDimensions = (
   imagePath: string,
 ): { width: number; height: number } | null => {
   const buffer = fs.readFileSync(imagePath);
 
-  // PNG: 89 50 4e 47 0d 0a 1a 0a, width/height at bytes 16-19 / 20-23
+  // PNG signature is the fixed 8-byte magic "89 50 4E 47 0D 0A 1A 0A".
+  // The IHDR chunk starts at byte 8 and its layout is spec-pinned:
+  //   [8..11]  chunk length     (always 13 for IHDR)
+  //   [12..15] chunk type       ("IHDR")
+  //   [16..19] width            (big-endian uint32)
+  //   [20..23] height           (big-endian uint32)
+  // Because IHDR is always the first chunk, we can read the dimensions
+  // directly at those offsets without parsing anything else.
   if (buffer.slice(0, 8).toString("hex") === "89504e470d0a1a0a") {
     const width = buffer.readUInt32BE(16);
     const height = buffer.readUInt32BE(20);
     return { width, height };
   }
 
-  // JPG: ff d8, scan for SOF marker (0xC0-0xC3) to extract dimensions
+  // JPG starts with the SOI marker "FF D8". The file is a sequence of
+  // markers, each shaped like:
+  //   FF <marker-code> <length:uint16 BE> <payload of (length-2) bytes>
+  // Dimensions live in a Start-Of-Frame (SOF) marker — codes 0xC0..0xC3
+  // cover the common baseline/progressive/lossless variants. The SOF
+  // payload layout is:
+  //   +0  precision (1 byte)
+  //   +1  height    (uint16 BE)
+  //   +3  width     (uint16 BE)
+  // Relative to the marker's FF byte at index i, that's i+5 / i+7.
+  //
+  // We walk the marker chain by jumping (segmentLength + 2) bytes each
+  // iteration — +2 accounts for the FF/code bytes that aren't part of the
+  // declared length. We stop as soon as we hit an SOF.
   if (buffer.slice(0, 2).toString("hex") === "ffd8") {
     let i = 2;
     while (i < buffer.length) {

--- a/scripts/validateImages.ts
+++ b/scripts/validateImages.ts
@@ -3,11 +3,14 @@
 import fs from "node:fs";
 import path from "node:path";
 import chalk from "chalk";
-import sharp from "sharp";
-import { isAddress } from "viem";
 import type { TokensFile } from "../src/types/tokens";
 import type { ValidatorsFile } from "../src/types/validators";
 import type { VaultsFile } from "../src/types/vaults";
+import {
+  getImageDimensions,
+  hasTransparency,
+  isValidChecksumAddress,
+} from "./utils/_imageChecks";
 
 // Config
 // ================================================================
@@ -17,59 +20,6 @@ const METADATA_FOLDER_EXCLUDED = ["assets"];
 
 // Functions
 // ================================================================
-/**
- * Validates if an Ethereum address is in proper checksum format
- * @param address - The address to validate
- * @returns true if the address is properly checksummed, false otherwise
- */
-const isValidChecksumAddress = (address: string): boolean => {
-  return isAddress(address);
-};
-
-/**
- * Reads the dimensions of an image file for PNG and JPG files
- * @param imagePath - The path to the image file
- * @returns The width and height of the image, or null if the file is not a valid image
- */
-const getImageDimensions = (
-  imagePath: string,
-): { width: number; height: number } | null => {
-  const buffer = fs.readFileSync(imagePath);
-
-  // Check PNG header
-  if (buffer.slice(0, 8).toString("hex") === "89504e470d0a1a0a") {
-    // PNG files start with 8 bytes: 89 50 4e 47 0d 0a 1a 0a
-    // The width and height are located at bytes 16-19 (width) and 20-23 (height)
-    const width = buffer.readUInt32BE(16);
-    const height = buffer.readUInt32BE(20);
-    return { width, height };
-  }
-
-  // Check JPG header
-  if (buffer.slice(0, 2).toString("hex") === "ffd8") {
-    // JPG files start with ff d8
-    let i = 2;
-    while (i < buffer.length) {
-      // Get segment length (2 bytes)
-      const segmentLength = buffer.readUInt16BE(i + 2);
-      if (
-        buffer[i] === 0xff &&
-        buffer[i + 1] >= 0xc0 &&
-        buffer[i + 1] <= 0xc3
-      ) {
-        // Start of frame (SOF) marker, contains width and height in the segment
-        const height = buffer.readUInt16BE(i + 5);
-        const width = buffer.readUInt16BE(i + 7);
-        return { width, height };
-      }
-      i += segmentLength + 2;
-    }
-  }
-
-  // Unsupported file format
-  return null;
-};
-
 /**
  * Validates that a URL returns a 200 OK status
  * @param url - The URL to validate
@@ -81,44 +31,6 @@ const validateUrl = async (url: string): Promise<boolean> => {
     return response.ok;
   } catch (error) {
     console.warn(`Warning: Could not validate URL ${url}:`, error);
-    return false;
-  }
-};
-
-/**
- * Checks if a PNG image has transparent pixels
- * @param imagePath - The path to the PNG image file
- * @returns Promise<boolean> - true if the image has transparent pixels, false otherwise
- */
-const hasTransparency = async (imagePath: string): Promise<boolean> => {
-  try {
-    const image = sharp(imagePath);
-    const metadata = await image.metadata();
-
-    // Only check PNG files for transparency
-    if (metadata.format !== "png") {
-      return false;
-    }
-
-    // Get the raw pixel data
-    const { data } = await image
-      .raw()
-      .ensureAlpha()
-      .toBuffer({ resolveWithObject: true });
-
-    // Check if any pixel has an alpha value less than 255 (transparent)
-    for (let i = 3; i < data.length; i += 4) {
-      if (data[i] < 255) {
-        return true;
-      }
-    }
-
-    return false;
-  } catch (error) {
-    console.warn(
-      `Warning: Could not check transparency for ${imagePath}:`,
-      error,
-    );
     return false;
   }
 };


### PR DESCRIPTION
## Summary

- Adds a CI pipeline that uploads contributor-added images under `src/assets/{tokens,vaults,validators}/` to Cloudflare Images, so `validate:images` no longer fails for PRs from contributors who don't have Cloudflare credentials.
- Gated behind the `cloudflare-uploads` GitHub Environment with required reviewers — every asset-changing PR pauses on "Waiting for review" before any secret is exposed.
- Re-runs image validation automatically after upload, so the `images` check turns green in the same workflow run.

## How it works

New jobs in `.github/workflows/validate.yml`:

- `detect-changes` — uses `dorny/paths-filter@v3` to set `assets-changed` output. No secrets.
- `upload-assets` — `needs: [schema, detect-changes]`, `if: assets-changed == 'true'`, `environment: cloudflare-uploads`. Runs `pnpm upload:assets ./head`. For JSON-only PRs this is skipped before the environment prompt is ever requested.
- `images` — reordered: now `needs: [schema, upload-assets]` with `if: always() && schema == success && (upload-assets == success || skipped)`. This makes image validation re-run after upload, and still runs immediately for JSON-only PRs (skipped dep counts as satisfied).

The new `scripts/uploadAssets.ts`:

1. Resolves changed `src/assets/**` files via `gh api /repos/{repo}/pulls/{pr}/files --paginate` (base-branch script against PR head bytes — untrusted PR code is never executed).
2. Per-file validates path, extension, filename regex, EIP-55 checksum (tokens/vaults), 1024×1024 dimensions, PNG non-transparency, and 5 MB cap — reusing helpers extracted to `scripts/utils/_imageChecks.ts`.
3. Uploads with `id = "{type}/{filename}"` matching `addVaultLogo.ts` convention.
4. On Cloudflare error 5409 `ALREADY_EXISTS`: DELETE then retry POST once (overwrite mode).
5. Writes a markdown summary to `$GITHUB_STEP_SUMMARY`, posts it as a PR comment, and exits non-zero on any failure.

## Security model (defense in depth)

1. **GitHub Environment `cloudflare-uploads` with required reviewers** — the sole secrets gate. Secrets live on the environment, not the repo, so no other job ever sees them.
2. **No PR-authored code is executed** — base branch is checked out at root and runs `pnpm install` + `scripts/uploadAssets.ts`; PR head is checked out to `./head` and only image bytes are read from there. PR head is pinned to `pull_request.head.sha` (frozen at event time) to prevent a force-push race between approval and checkout.
3. **Per-file static validation before any Cloudflare call** — path allowlist, filename regex, checksum, dimensions, transparency, size cap. A malicious PR cannot get a file uploaded that doesn't pass all checks.
4. Workflow permissions stay `contents: read`; only `upload-assets` gets `pull-requests: write` for its summary comment.

## One-time repo setup

Needs to happen in repo Settings before the workflow is useful:

1. Create GitHub Environment `cloudflare-uploads` with **required reviewers** = maintainers allowed to approve uploads. Optionally restrict to `main` branch.
2. Add environment secrets `CLOUDFLARE_ACCOUNT_ID` and `CLOUDFLARE_IMAGES_API_TOKEN` (token scoped to **Cloudflare Images: Edit** only).

## Test plan

- [ ] On a test fork PR that adds `src/assets/tokens/0x<checksum>.png` (1024×1024, no transparency): confirm `detect-changes` outputs `assets-changed=true`, `upload-assets` pauses on "Waiting for review", approving unlocks the upload, and `images` then runs green in the same run.
- [ ] Push a new commit to the same PR replacing the image: confirm the `5409 → DELETE → re-POST` path runs and the summary shows the file under `overwritten`.
- [ ] Push a commit that mutates `./head/scripts/uploadAssets.ts`: confirm the workflow still executes the base-branch script (no untrusted code runs).
- [ ] Submit a 512×512 image or a file with a non-checksum address: confirm the upload step rejects it before any Cloudflare call, and `images` subsequently fails with HEAD 404.
- [ ] Open a JSON-only PR: confirm `upload-assets` is skipped (no environment prompt) and `images` runs immediately and passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)