### PR TITLE
fix: disable setup-node v5 auto-cache (pnpm not yet installed)

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -26,6 +26,7 @@ jobs:
       uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
       with:
         node-version-file: '.nvmrc'
+        package-manager-cache: false
 
     - name: Setup pnpm
       uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
@@ -71,6 +72,7 @@ jobs:
       uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
       with:
         node-version-file: '.nvmrc'
+        package-manager-cache: false
 
     - name: Setup pnpm
       uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
@@ -116,6 +118,7 @@ jobs:
       uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
       with:
         node-version-file: '.nvmrc'
+        package-manager-cache: false
 
     - name: Setup pnpm
       uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
@@ -187,6 +190,7 @@ jobs:
       uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
       with:
         node-version-file: '.nvmrc'
+        package-manager-cache: false
 
     - name: Setup pnpm
       uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
@@ -249,6 +253,7 @@ jobs:
       uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
       with:
         node-version-file: '.nvmrc'
+        package-manager-cache: false
 
     - name: Setup pnpm
       uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
@@ -295,6 +300,7 @@ jobs:
       uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
       with:
         node-version-file: '.nvmrc'
+        package-manager-cache: false
 
     - name: Setup pnpm
       uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
@@ -340,6 +346,7 @@ jobs:
       uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
       with:
         node-version-file: '.nvmrc'
+        package-manager-cache: false
 
     - name: Setup pnpm
       uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8


### PR DESCRIPTION
this PR unblocks #392 and needs an admin bypass.

`actions/setup-node@v5` introduced automatic package manager caching — when it detects a `packageManager` field in `package.json`, it tries to resolve and cache that package manager before any other steps run. Since `pnpm/action-setup` runs AFTER `setup-node`, pnpm isn't on PATH yet and the step fails with:

```
Error: Unable to locate executable file: pnpm
```

This is a known v5 breaking change: https://github.com/actions/setup-node/issues/1351

Fix: add `package-manager-cache: false` to all `setup-node` steps. The workflow already has manual `actions/cache` steps for the pnpm store, so the auto-cache is redundant anyway.

@bearpong Same chicken-and-egg as the lockfile fix — `pull_request_target` runs main's workflow, so this needs an admin-bypass merge to unblock CI. One-line addition per job, no behavioral changes.