### PR TITLE
chore: fix base pull_request_target CI failures

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,6 +1,8 @@
 {
   "$schema": "https://biomejs.dev/schemas/2.5.0/schema.json",
-  "root": false,
+  "files": {
+    "includes": ["**", "!!head/biome.json"]
+  },
   "formatter": {
     "indentStyle": "space",
     "indentWidth": 2

--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://biomejs.dev/schemas/2.5.0/schema.json",
+  "root": false,
   "formatter": {
     "indentStyle": "space",
     "indentWidth": 2

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
   "dependencies": {
     "@actions/core": "^1.11.1",
     "@berachain/berajs": "0.2.12",
+    "bignumber.js": "^11.1.4",
     "chalk": "^5.6.2",
     "cloudinary": "2.10.0",
     "jsonc-parser": "3.3.1",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   "dependencies": {
     "@actions/core": "^1.11.1",
     "@berachain/berajs": "0.2.12",
-    "bignumber.js": "^11.1.4",
+    "bignumber.js": "11.1.4",
     "chalk": "^5.6.2",
     "cloudinary": "2.10.0",
     "jsonc-parser": "3.3.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,7 +15,7 @@ importers:
         specifier: 0.2.12
         version: 0.2.12(6rsrvffv7x2rcjxezrnwrcergq)
       bignumber.js:
-        specifier: ^11.1.4
+        specifier: 11.1.4
         version: 11.1.4
       chalk:
         specifier: ^5.6.2

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@berachain/berajs':
         specifier: 0.2.12
         version: 0.2.12(6rsrvffv7x2rcjxezrnwrcergq)
+      bignumber.js:
+        specifier: ^11.1.4
+        version: 11.1.4
       chalk:
         specifier: ^5.6.2
         version: 5.6.2
@@ -3277,6 +3280,9 @@ packages:
 
   big.js@6.2.2:
     resolution: {integrity: sha512-y/ie+Faknx7sZA5MfGA2xKlu0GDv8RWrXGsmlteyJQ2lvoKv9GBK/fpRMc2qlSoBAgNxrixICFCBefIq8WCQpQ==}
+
+  bignumber.js@11.1.4:
+    resolution: {integrity: sha512-AJ9dSeaUGj2xu7tEwmdqb51dqdb633xo4njI9K8ZFfcLrNr0XN8/EPkkZUNaF9fkCblGt2zVwZymesUdGynEkQ==}
 
   binary-extensions@2.3.0:
     resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
@@ -10672,6 +10678,8 @@ snapshots:
   baseline-browser-mapping@2.10.30: {}
 
   big.js@6.2.2: {}
+
+  bignumber.js@11.1.4: {}
 
   binary-extensions@2.3.0:
     optional: true


### PR DESCRIPTION
## Summary
- mark biome.json as non-root so Biome 2.5 can validate PR checkouts nested under ./head
- add missing bignumber.js dependency required by @berachain/berajs@0.2.12

## Root cause
- PR validation checks out base at the workspace root and the PR under ./head
- Biome 2.5 errors when both locations contain root configs
- @berachain/berajs@0.2.12 imports bignumber.js, but base dependencies did not install it

## Verification
- CI=true pnpm install --frozen-lockfile
- pnpm validate:data .
- pnpx @biomejs/biome@2.5.0 ci ./head in a simulated base + nested PR checkout