### PR TITLE
chore: add ebtc coingecko id

### DIFF
--- a/src/tokens/mainnet.json
+++ b/src/tokens/mainnet.json
@@ -1397,6 +1397,7 @@
       "name": "ether.fi BTC",
       "decimals": 8,
       "extensions": {
+        "coingeckoId": "ether-fi-staked-btc",
         "pythPriceId": "0xbe3dd0cf4a168f82e4912952b24420211ad52641b7365d49866d59e20c948288"
       }
     },


### PR DESCRIPTION
Adds the CoinGecko ID `ether-fi-staked-btc` to the eBTC mainnet token metadata.

Validation:
- `pnpm biome check src/tokens/mainnet.json`
- `pnpm validate:json .`
- `pnpm validate:coingecko