### PR TITLE
chore(deps): 공급망 age gate 활성화 (pnpm minimumReleaseAge)

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,13 @@
     "lint": "biome lint .",
     "check": "biome check ."
   },
-  "keywords": ["berachain", "metadata", "tokens", "validators", "vaults"],
+  "keywords": [
+    "berachain",
+    "metadata",
+    "tokens",
+    "validators",
+    "vaults"
+  ],
   "author": "",
   "license": "ISC",
   "type": "module",
@@ -27,7 +33,7 @@
   "engines": {
     "node": "22"
   },
-  "packageManager": "pnpm@9.15.9+sha512.68046141893c66fad01c079231128e9afb89ef87e2691d69e4d40eee228988295fd4682181bae55b58418c3a253bde65a505ec7c5f9403ece5cc3cd37dcf2531",
+  "packageManager": "pnpm@10.18.1",
   "dependencies": {
     "@actions/core": "^1.11.1",
     "jsonc-parser": "^3.3.1"

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+# 공급망 age gate: 신규 해석 버전은 게시 후 7일(10080분) 경과분만 설치 (pnpm ≥ 10.16)
+minimumReleaseAge: 10080


### PR DESCRIPTION
## 배경
harness dependency-policy 요건: pnpm age gate는 `pnpm-workspace.yaml`의 `minimumReleaseAge`(pnpm ≥ 10.16)로 설정해야 실효한다. 이 repo는 gate가 없었다.

## 변경 내용 및 검증
- `pnpm-workspace.yaml` 신설: `minimumReleaseAge: 10080`
- `packageManager`: pnpm@9.15.9 → pnpm@10.18.1 (9.x는 minimumReleaseAge 미지원)
- 검증: `pnpm install --frozen-lockfile` 정상 (pnpm 10.18.1, lockfile 무변경). 로컬 node 24 환경이라 engines.node=22의 engine-strict에 걸려 검증 시에만 `--config.engine-strict=false` 사용 — repo 설정은 무변경
- 참고: remote가 SSH였는데 push 인증 실패로 git-convention에 따라 HTTPS로 전환함

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JjyCVy3Mv4i9p9YBCFpyvK