### PR TITLE
chore: add coingecko id to bepolia honey

### DIFF
--- a/src/tokens/bepolia.json
+++ b/src/tokens/bepolia.json
@@ -108,6 +108,7 @@
       "decimals": 18,
       "tags": [],
       "extensions": {
+        "coingeckoId": "usd-coin",
         "pythPriceId": "0xeaa020c61cc479712813461ce153894a96a6c00b21ed0cfc2798d1f9a9e9c94a"
       }
     },
@@ -119,6 +120,7 @@
       "decimals": 18,
       "tags": [],
       "extensions": {
+        "coingeckoId": "usd-coin",
         "pythPriceId": "0xeaa020c61cc479712813461ce153894a96a6c00b21ed0cfc2798d1f9a9e9c94a"
       }
     },
@@ -130,6 +132,7 @@
       "decimals": 18,
       "tags": [],
       "extensions": {
+        "coingeckoId": "usd-coin",
         "pythPriceId": "0xeaa020c61cc479712813461ce153894a96a6c00b21ed0cfc2798d1f9a9e9c94a"
       }
     },
@@ -141,6 +144,7 @@
       "decimals": 18,
       "tags": [],
       "extensions": {
+        "coingeckoId": "usd-coin",
         "pythPriceId": "0xeaa020c61cc479712813461ce153894a96a6c00b21ed0cfc2798d1f9a9e9c94a"
       }
     },
@@ -152,6 +156,7 @@
       "decimals": 18,
       "tags": [],
       "extensions": {
+        "coingeckoId": "usd-coin",
         "pythPriceId": "0xeaa020c61cc479712813461ce153894a96a6c00b21ed0cfc2798d1f9a9e9c94a"
       }
     },
@@ -163,6 +168,7 @@
       "decimals": 18,
       "tags": [],
       "extensions": {
+        "coingeckoId": "usd-coin",
         "pythPriceId": "0xeaa020c61cc479712813461ce153894a96a6c00b21ed0cfc2798d1f9a9e9c94a"
       }
     },
@@ -174,6 +180,7 @@
       "decimals": 18,
       "tags": [],
       "extensions": {
+        "coingeckoId": "usd-coin",
         "pythPriceId": "0xeaa020c61cc479712813461ce153894a96a6c00b21ed0cfc2798d1f9a9e9c94a"
       }
     },

--- a/src/tokens/bepolia.json
+++ b/src/tokens/bepolia.json
@@ -57,6 +57,7 @@
       "logoURI": "https://imagedelivery.net/qNj7Q3MCke89zoKzav7eDQ/tokens/0xfcbd14dc51f0a4d49d5e53c2e0950e0bc26d0dce.png/public",
       "tags": ["stablecoin", "featured"],
       "extensions": {
+        "coingeckoId": "honey-3",
         "pythPriceId": "0xf67b033925d73d43ba4401e00308d9b0f26ab4fbd1250e8b5407b9eaade7e1f4"
       }
     },


### PR DESCRIPTION
Adds the CoinGecko ID `honey-3` to the HONEY token metadata on Berachain Bepolia.

Validation:
- `pnpm biome check src/tokens/bepolia.json`
- `pnpm validate:json .`
- `pnpm validate:images .`
- `pnpm validate:coingecko