### PR TITLE
chore: add missing vault actions

### DIFF
--- a/src/vaults/bepolia.json
+++ b/src/vaults/bepolia.json
@@ -29,7 +29,8 @@
       "protocol": "HUB",
       "categories": ["foundation"],
       "url": "https://bepolia.hub.berachain.com/vaults/0x57abe4e0c59a650a7042e18493179dd5b91a3f61",
-      "description": "Bribes automation, Owned by BD team"
+      "description": "Bribes automation, Owned by BD team",
+      "action": "Provide liquidity on BEX"
     },
     {
       "stakingTokenAddress": "0xA9d09e1Bd86bBAFeac4020099207eE23549618B0",
@@ -38,7 +39,8 @@
       "protocol": "HUB",
       "categories": ["foundation"],
       "url": "https://bepolia.hub.berachain.com/vaults/0xae461ea8238df1bd63B3f93b0EF7da1A56De2f91",
-      "description": "Bribes automation, Owned by BD team"
+      "description": "Bribes automation, Owned by BD team",
+      "action": "Provide liquidity on BEX"
     },
     {
       "stakingTokenAddress": "0x5bA554fA6faDc5583eD99d09E0545dB4bC9f994d",
@@ -47,7 +49,8 @@
       "protocol": "HUB",
       "categories": ["foundation"],
       "url": "https://bepolia.hub.berachain.com/vaults/0x45450D1E3bfd42E224976a7a263F7e59AB9607C8",
-      "description": "Bribes automation, Owned by BD team"
+      "description": "Bribes automation, Owned by BD team",
+      "action": "Provide liquidity on BEX"
     },
     {
       "stakingTokenAddress": "0xe5C337e10089246afE8DA5752BB1777613F70aa9",
@@ -56,7 +59,8 @@
       "protocol": "HUB",
       "categories": ["foundation"],
       "url": "https://bepolia.hub.berachain.com/vaults/0x3bcED9bC841a862716d58560c07480c203e61912",
-      "description": "Owned by Frontend Team"
+      "description": "Owned by Frontend Team",
+      "action": "Provide liquidity on BEX"
     },
     {
       "stakingTokenAddress": "0x9d323a87597667d7373CF9C2F758a29896f6496A",
@@ -64,7 +68,8 @@
       "name": "Bepolia Foundation Vault #5",
       "protocol": "HUB",
       "categories": ["foundation"],
-      "url": "https://bepolia.hub.berachain.com/vaults/0x668b25f09D1f505b774bb5F686874c401EE22730"
+      "url": "https://bepolia.hub.berachain.com/vaults/0x668b25f09D1f505b774bb5F686874c401EE22730",
+      "action": "Provide liquidity on BEX"
     }
   ]
 }

--- a/src/vaults/bepolia.json
+++ b/src/vaults/bepolia.json
@@ -30,7 +30,7 @@
       "categories": ["foundation"],
       "url": "https://bepolia.hub.berachain.com/vaults/0x57abe4e0c59a650a7042e18493179dd5b91a3f61",
       "description": "Bribes automation, Owned by BD team",
-      "action": "Provide liquidity on BEX"
+      "action": "Stake BST-1"
     },
     {
       "stakingTokenAddress": "0xA9d09e1Bd86bBAFeac4020099207eE23549618B0",
@@ -40,7 +40,7 @@
       "categories": ["foundation"],
       "url": "https://bepolia.hub.berachain.com/vaults/0xae461ea8238df1bd63B3f93b0EF7da1A56De2f91",
       "description": "Bribes automation, Owned by BD team",
-      "action": "Provide liquidity on BEX"
+      "action": "Stake BST-2"
     },
     {
       "stakingTokenAddress": "0x5bA554fA6faDc5583eD99d09E0545dB4bC9f994d",
@@ -50,7 +50,7 @@
       "categories": ["foundation"],
       "url": "https://bepolia.hub.berachain.com/vaults/0x45450D1E3bfd42E224976a7a263F7e59AB9607C8",
       "description": "Bribes automation, Owned by BD team",
-      "action": "Provide liquidity on BEX"
+      "action": "Stake BST-3"
     },
     {
       "stakingTokenAddress": "0xe5C337e10089246afE8DA5752BB1777613F70aa9",
@@ -60,7 +60,7 @@
       "categories": ["foundation"],
       "url": "https://bepolia.hub.berachain.com/vaults/0x3bcED9bC841a862716d58560c07480c203e61912",
       "description": "Owned by Frontend Team",
-      "action": "Provide liquidity on BEX"
+      "action": "Stake BST-4"
     },
     {
       "stakingTokenAddress": "0x9d323a87597667d7373CF9C2F758a29896f6496A",
@@ -69,7 +69,7 @@
       "protocol": "HUB",
       "categories": ["foundation"],
       "url": "https://bepolia.hub.berachain.com/vaults/0x668b25f09D1f505b774bb5F686874c401EE22730",
-      "action": "Provide liquidity on BEX"
+      "action": "Stake BST-5"
     }
   ]
 }

--- a/src/vaults/mainnet.json
+++ b/src/vaults/mainnet.json
@@ -3063,7 +3063,8 @@
       "categories": ["defi/yield"],
       "logoURI": "https://imagedelivery.net/qNj7Q3MCke89zoKzav7eDQ/vaults/0xc6dd0727f00cda3972be452f2009ec4973cd74d0.jpg/public",
       "url": "https://apiologydao.0xhoneyjar.xyz/auctions",
-      "description": "apDAO treasury vault for managing and distributing rewards within the apDAO ecosystem. The staking token (vAPDAO) is held exclusively by the apDAO treasury."
+      "description": "apDAO treasury vault for managing and distributing rewards within the apDAO ecosystem. The staking token (vAPDAO) is held exclusively by the apDAO treasury.",
+      "action": "Stake vAPDAO"
     },
     {
       "stakingTokenAddress": "0xe15db2653d0bb242e09066e97c231c1404fca45d",
@@ -3075,16 +3076,6 @@
       "url": "https://app.charm.fi/berachain/vault/0xe15db2653d0bb242e09066e97c231c1404fca45d",
       "description": "Charm vault managing iBERA/iBGT liquidity. This vault ensures BGT emissions are routed to productive pools, increasing chain revenue and supporting iBGT economics through fee-earning activity.",
       "action": "Stake iBERA / iBGT"
-    },
-    {
-      "stakingTokenAddress": "0xde1392209e55313284f144f8e76dcbb1c8a2eee3",
-      "vaultAddress": "0x84cde2880f1c63253636501d757630c252678562",
-      "name": "Narra Vault",
-      "protocol": "Narra Agents",
-      "categories": ["defi/yield"],
-      "logoURI": "https://imagedelivery.net/qNj7Q3MCke89zoKzav7eDQ/vaults/0x84cde2880f1c63253636501d757630c252678562.png/public",
-      "url": "https://vault.narralayer.ai",
-      "description": "Narra Agents PoL game vault. Users earn Pre-Narra (ZAI Points) through activities like holding NFTs and accumulating points. Deposited tokens are burned and converted into staking tokens (NANA) according to the set weight, which are then delegated for reward mining. Rewards can be claimed after the cooldown period. The vault includes a public leaderboard for transparency and real-time point tracking."
     },
     {
       "stakingTokenAddress": "0xb350944be03cf5f795f48b63eaa542df6a3c8505",
@@ -3105,17 +3096,8 @@
       "categories": ["defi/yield"],
       "logoURI": "https://imagedelivery.net/qNj7Q3MCke89zoKzav7eDQ/vaults/0xfbef3678faeb671e352b0f9ad87b402243beaf24.png/public",
       "url": "https://berapaw.com",
-      "description": "BeraPaw Rewards incentivizes LBGT and pBERA liquidity to grow BeraPaw TVL and Berachain's. Rewards enable money market integrations and attract TVL from current and new users. BeraPaw is a liquid staking protocol."
-    },
-    {
-      "stakingTokenAddress": "0x6170da95cf074d891a8e7bdc9583ee51915cc859",
-      "vaultAddress": "0xc91ac72d1051b8c128ded1b00f55f6e2decd75aa",
-      "name": "Pendle Market Wrapped",
-      "protocol": "Pendle",
-      "categories": ["defi/derivatives"],
-      "logoURI": "https://imagedelivery.net/qNj7Q3MCke89zoKzav7eDQ/vaults/0xc91ac72d1051b8c128ded1b00f55f6e2decd75aa.jpg/public",
-      "url": "https://app.pendle.finance/trade/markets",
-      "description": "Wrapped Pendle market position token. No longer supported but data remains visible."
+      "description": "BeraPaw Rewards incentivizes LBGT and pBERA liquidity to grow BeraPaw TVL and Berachain's. Rewards enable money market integrations and attract TVL from current and new users. BeraPaw is a liquid staking protocol.",
+      "action": "Stake LBGT / pBERA"
     },
     {
       "stakingTokenAddress": "0x34054679536b60406328eda38617cd027b9e3d30",
@@ -3137,7 +3119,8 @@
       "categories": ["defi/yield"],
       "logoURI": "https://imagedelivery.net/qNj7Q3MCke89zoKzav7eDQ/vaults/0xbfc1be70d7b997ee386204b0bbf93107f38359a1.png/public",
       "url": "https://app.charm.fi/berachain/vault/0xf0dab9d5da8ded3aa66698f59cc00a5720e65dfb",
-      "description": "Beraborrow's uniBTC | NECT Charm Vault deepens stablecoin liquidity and strengthens NECT's peg. It attracts BTC-based capital from external chains, onboard new users, and expands leverage opportunities within Beraborrow."
+      "description": "Beraborrow's uniBTC | NECT Charm Vault deepens stablecoin liquidity and strengthens NECT's peg. It attracts BTC-based capital from external chains, onboard new users, and expands leverage opportunities within Beraborrow.",
+      "action": "Stake uniBTC / NECT"
     },
     {
       "stakingTokenAddress": "0xde8819788bb9dbfa7855ab8cd3e761a716d098ff",
@@ -3158,7 +3141,8 @@
       "categories": ["defi/lending"],
       "logoURI": "https://imagedelivery.net/qNj7Q3MCke89zoKzav7eDQ/vaults/0xd5e32d4d7920a876417ef2ecbbafb58b38f717ac.png/public",
       "url": "https://app.sumer.money",
-      "description": "sweETH is an action-based incentive vault using a dummy ERC-20 token to represent user actions: deposit weETH, borrow BERA, swap for iBGT, deposit iBGT, and loop. Auto-staked to accumulate BGT rewards, supporting PoL goals through iBGT/BERA looping and DEX volume."
+      "description": "sweETH is an action-based incentive vault using a dummy ERC-20 token to represent user actions: deposit weETH, borrow BERA, swap for iBGT, deposit iBGT, and loop. Auto-staked to accumulate BGT rewards, supporting PoL goals through iBGT/BERA looping and DEX volume.",
+      "action": "Loop iBGT / BERA on Sumer"
     },
     {
       "stakingTokenAddress": "0x4decb02b9a838ad66ebcafac3c8a3b12087a8976",
@@ -3248,7 +3232,8 @@
       "categories": ["defi/yield"],
       "logoURI": "https://imagedelivery.net/qNj7Q3MCke89zoKzav7eDQ/vaults/0xb0a43571178bd0fafb2d2def02037ed061ce4919.png/public",
       "url": "https://hub.berachain.com",
-      "description": "Placeholder entry for i-IR-BERA vault. Metadata needs to be added."
+      "description": "Placeholder entry for i-IR-BERA vault. Metadata needs to be added.",
+      "action": "Stake i-IR-BERA"
     },
     {
       "stakingTokenAddress": "0x200c2c7879e885ed9d6a5d2ad4f6cdfc525a52c4",


### PR DESCRIPTION
## Summary

- add action metadata to five active mainnet reward vaults
- add BEX liquidity actions to five Bepolia Foundation vaults
- remove the non-whitelisted Narra and Pendle reward vaults

## Validation

- `pnpm biome check src/vaults/mainnet.json`
- `pnpm biome check src/vaults/bepolia.json`
- `pnpm validate:json .`